### PR TITLE
Chms 3113 - enhancement -  pass exit codes back up to the parent process

### DIFF
--- a/bin/tapegun
+++ b/bin/tapegun
@@ -1,6 +1,11 @@
 #!/usr/bin/env php
 <?php
 
+//only want to see errors once in terminal (logs go to std out in a default php cli setup)
+if (ini_get('log_errors') && ini_get('display_errors') ) {
+    ini_set('log_errors', 0);
+}
+
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once(__DIR__ . '/../vendor/autoload.php');
 } elseif (file_exists(__DIR__ . '/../../../autoload.php')) {

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -10,8 +10,18 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
 try {
     $app = new \Symfony\Component\Console\Application('Tapegun', \Tapegun\Tapegun::VERSION);
     $app->add(new \Tapegun\Command\Build());
-    $app->run();
+    $run = $app->run();
+
+    if (intval($run) === 0){
+        echo "Operations successful. Exit code was $run";
+    } else {
+        echo "Error Operations failed with exit code $run";
+    }
+    //pass the exit code up the chain
+    exit($run);
 } catch (Exception $e) {
     echo 'Error: ' . $e->getMessage();
-    exit;
+    //exit with an error code
+    exit(2);
 }
+

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -18,14 +18,14 @@ try {
     $run = $app->run();
 
     if (intval($run) === 0){
-        echo "\n\n✔️ Operations successful. Exit code was $run";
+        echo "\n\n✔️ Operations successful. Exit code was $run \n";
     } else {
-        echo "\n\n❌ Error Operations failed with exit code $run";
+        echo "\n\n❌ Error Operations failed with exit code $run \n";
     }
     //pass the exit code up the chain
     exit($run);
-} catch (Exception $e) {
-    echo "\n\n❌ Error: " . $e->getMessage();
+} catch (Throwable $e) {
+    echo "\n\n❌ Error: " . $e->getMessage()."\n";
     //exit with an error code
     exit(2);
 }

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -18,7 +18,7 @@ try {
     $run = $app->run();
 
     if (intval($run) === 0){
-        echo "\n\n✔️ Operations successful. Exit code was $run \n";
+        echo "\n\n✔️ Operations successful.\n";
     } else {
         echo "\n\n❌ Error Operations failed with exit code $run \n";
     }

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -1,8 +1,12 @@
 #!/usr/bin/env php
 <?php
 
-//only want to see errors once in terminal (logs go to std out in a default php cli setup)
-if (ini_get('log_errors') && ini_get('display_errors') ) {
+//only want to see errors once in terminal window (logs go to std out in a default php cli setup)
+if (
+    ini_get('log_errors') &&
+    ini_get('display_errors') &&
+    ini_get('error_log') === ""
+) {
     ini_set('log_errors', 0);
 }
 

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -13,14 +13,14 @@ try {
     $run = $app->run();
 
     if (intval($run) === 0){
-        echo "Operations successful. Exit code was $run";
+        echo "\n\n✔️ Operations successful. Exit code was $run";
     } else {
-        echo "Error Operations failed with exit code $run";
+        echo "\n\n❌ Error Operations failed with exit code $run";
     }
     //pass the exit code up the chain
     exit($run);
 } catch (Exception $e) {
-    echo 'Error: ' . $e->getMessage();
+    echo "\n\n❌ Error: " . $e->getMessage();
     //exit with an error code
     exit(2);
 }


### PR DESCRIPTION
TapeGun will now attempt to pass error codes up to the parent process/shell that executed the command.
- Exits with a status of the operations performed.
 - Add a try-catch to pass an error code back when an exception is thrown.

Keyword "attempts" because many fail conditions do not seem to pass exit codes up the chain when running through the symphony console app being used and as such, can not be 100% relied on for the determination of a success/failure condition.

Additional enhancement:
Because PHP runs in CLI by default has two output streams pointed to stdout, any PHP errors that occur will be written to your terminal twice.
TapeGun now checks for custom error log setting and disables error logs if they will end up going to stdout.