### PR TITLE
Enable Errors and stop running if a task fails.

### DIFF
--- a/bin/tapegun
+++ b/bin/tapegun
@@ -7,11 +7,7 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once(__DIR__ . '/../../../autoload.php');
 }
 
-try {
-    $app = new \Symfony\Component\Console\Application('Tapegun', \Tapegun\Tapegun::VERSION);
-    $app->add(new \Tapegun\Command\Build());
-    $app->run();
-} catch (Exception $e) {
-    echo 'Error: ' . $e->getMessage();
-    exit;
-}
+$app = new \Symfony\Component\Console\Application('Tapegun', \Tapegun\Tapegun::VERSION);
+$app->setCatchExceptions(false);
+$app->add(new \Tapegun\Command\Build());
+$app->run();

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -17,7 +17,22 @@ if (
     ini_set('log_errors', '0');
 }
 
-$app = new \Symfony\Component\Console\Application('Tapegun', \Tapegun\Tapegun::VERSION);
-$app->setCatchExceptions(false);
-$app->add(new \Tapegun\Command\Build());
-$app->run();
+//if --debug flag, set error reporting and remove the debug flag before app runs
+if ($debugging = in_array('--debug', $argv)) {
+    //remove from argv since this is not a valid argument for the app.
+    $argv = array_diff($argv, ['--debug']);
+}
+
+try {
+    $app = new \Symfony\Component\Console\Application('Tapegun', \Tapegun\Tapegun::VERSION);
+    $app->setCatchExceptions(false);
+    $app->add(new \Tapegun\Command\Build());
+    $app->run();
+} catch (Exception $e) {
+    if ($debugging) {
+        throw $e;
+    } else {
+        echo $e->getMessage() . PHP_EOL;
+        exit(1);
+    }
+}

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -33,6 +33,11 @@ try {
         throw $e;
     } else {
         echo $e->getMessage() . PHP_EOL;
-        exit(1);
+        //allow users Php errors to pass back custom error codes within range.
+        $exitCode = min($e->getCode());
+        if ($exitCode < 1 || $exitCode > 255) {
+            $exitCode = 1;
+        }
+        exit($exitCode);
     }
 }

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -17,7 +17,7 @@ if (
     ini_set('log_errors', '0');
 }
 
-//if --debug flag, set error reporting and remove the debug flag before app runs
+//debug option will show errors.
 if ($debugging = in_array('--debug', $argv)) {
     //remove from argv since this is not a valid argument for the app.
     $argv = array_diff($argv, ['--debug']);

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -30,14 +30,8 @@ try {
     $app->run();
 } catch (\Throwable $e) {
     if ($debugging) {
-        throw $e;
-    } else {
-        echo $e->getMessage() . PHP_EOL;
-        //allow users Php errors to pass back custom error codes within range.
-        $exitCode = min($e->getCode());
-        if ($exitCode < 1 || $exitCode > 255) {
-            $exitCode = 1;
-        }
-        exit($exitCode);
+        throw $e;//php will exit with code 255
     }
+    echo $e->getMessage() . PHP_EOL;
+    exit(255);
 }

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -28,7 +28,7 @@ try {
     $app->setCatchExceptions(false);
     $app->add(new \Tapegun\Command\Build());
     $app->run();
-} catch (Exception $e) {
+} catch (\Throwable $e) {
     if ($debugging) {
         throw $e;
     } else {

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -32,6 +32,6 @@ try {
     if ($debugging) {
         throw $e;//php will exit with code 255
     }
-    echo $e->getMessage() . PHP_EOL;
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
     exit(255);
 }

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -7,6 +7,16 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once(__DIR__ . '/../../../autoload.php');
 }
 
+//Only print errors in terminals once.
+// Default php cli configs use terminal for both log and display which is too noisy.
+if (
+    ini_get('log_errors') &&
+    ini_get('display_errors') &&
+    ini_get('error_log') === ""
+) {
+    ini_set('log_errors', '0');
+}
+
 $app = new \Symfony\Component\Console\Application('Tapegun', \Tapegun\Tapegun::VERSION);
 $app->setCatchExceptions(false);
 $app->add(new \Tapegun\Command\Build());

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -22,13 +22,8 @@ class Build extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        try {
-            $manager = new Tapegun($input, $output, $this->getHelper('question'));
-            $manager->build(Config::fromFilePath($input->getOption('config')), $input->getOption('target'));
-            return 0;
-        } catch (\Exception $e) {
-            $output->writeln('<error>' . $e->getMessage() . '</error>');
-            return 1;
-        }
+        $manager = new Tapegun($input, $output, $this->getHelper('question'));
+        $manager->build(Config::fromFilePath($input->getOption('config')), $input->getOption('target'));
+        return 0;
     }
 }

--- a/src/Tapegun.php
+++ b/src/Tapegun.php
@@ -72,7 +72,7 @@ class Tapegun
             $this->output->writeln('<comment>======> </comment>' . $task->getDescription());
 
             if (!$task->run()) {
-                return;
+                throw new \Exception("Task failed: " . $task->getDescription());
             }
         }
 


### PR DESCRIPTION
It's better if the user of the library decides how errors are handled esp if it's mostly running their own code.