### PR TITLE
hotfix-explicit-input

### DIFF
--- a/bin/tapegun
+++ b/bin/tapegun
@@ -23,9 +23,9 @@ if (
 }
 
 //debug option will show errors.
-if ($debugging = in_array('--debug', $argv)) {
+if ($showErrors = in_array('--tapegun-show-errors', $argv)) {
     //remove from argv since this is not a valid argument for the app.
-    $input = array_diff($argv, ['--debug']);
+    $input = array_diff($argv, ['--tapegun-show-errors']);
 } else {
     $input = $argv;
 }
@@ -36,7 +36,7 @@ try {
     $app->add(new Build());
     $app->run(new ArgvInput($input));
 } catch (\Throwable $e) {
-    if ($debugging) {
+    if ($showErrors) {
         throw $e;//php will exit with code 255
     }
     echo 'Error: ' . $e->getMessage() . PHP_EOL;

--- a/bin/tapegun
+++ b/bin/tapegun
@@ -1,6 +1,11 @@
 #!/usr/bin/env php
 <?php
 
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Tapegun\Command\Build;
+use Tapegun\Tapegun;
+
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once(__DIR__ . '/../vendor/autoload.php');
 } elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
@@ -20,14 +25,16 @@ if (
 //debug option will show errors.
 if ($debugging = in_array('--debug', $argv)) {
     //remove from argv since this is not a valid argument for the app.
-    $argv = array_diff($argv, ['--debug']);
+    $input = array_diff($argv, ['--debug']);
+} else {
+    $input = $argv;
 }
 
 try {
-    $app = new \Symfony\Component\Console\Application('Tapegun', \Tapegun\Tapegun::VERSION);
+    $app = new Application('Tapegun', Tapegun::VERSION);
     $app->setCatchExceptions(false);
-    $app->add(new \Tapegun\Command\Build());
-    $app->run();
+    $app->add(new Build());
+    $app->run(new ArgvInput($input));
 } catch (\Throwable $e) {
     if ($debugging) {
         throw $e;//php will exit with code 255


### PR DESCRIPTION
The previous update had an issue with the debug option.
It was meant to be exclusive to the binary file however, the symphony console library was still detecting the argument and passing it along.

Additionally, I thought it best if the option was more specific eg. `--tapegun-show-errors` since `--debug` might clash if a user chooses to implement the same option.